### PR TITLE
#3 매물 조회 API 기능 완성

### DIFF
--- a/tiptapProject/api/admin.py
+++ b/tiptapProject/api/admin.py
@@ -1,7 +1,7 @@
 from django.contrib import admin
 
 # Register your models here.
-from app.models import Checklist
+from app.models import CheckList
 
 # admin 페이지에서 확인할 모델 추가
-admin.register(Checklist)
+admin.register(CheckList)

--- a/tiptapProject/api/serializers.py
+++ b/tiptapProject/api/serializers.py
@@ -1,3 +1,45 @@
 from rest_framework import serializers
+from app.models import BrokerAgency, CheckList, Image, Room, RoomInfo, Tag
 
-# Create your serializers here.
+# RoomInfoSerializer: Created by @ssanghy on checklist
+class RoomInfoSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = RoomInfo
+        exclude = ('roominfo_id', )
+
+
+class TagSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Tag
+        fields = '__all__'
+
+
+class BrokerAgencySerializer(serializers.ModelSerializer):
+    class Meta:
+        model = BrokerAgency
+        fields = ('brokerAgency_id', 'brokerAgency_name', 'brokerAgency_number1')
+
+
+class RoomSerializer(serializers.ModelSerializer):
+    roomInfo = RoomInfoSerializer()
+    tag = TagSerializer(many=True, read_only=True)
+    thumbnail = serializers.SerializerMethodField()
+    images = serializers.SerializerMethodField()
+
+    def get_thumbnail(self, obj):
+        images = obj.roomInfo.image_set.all()
+        if images:
+            return images[0].image.url
+        return []
+
+    def get_images(self, obj):
+        images = obj.roomInfo.image_set.all()
+        image_list = []
+        for i in images:
+            image_list.append(i.image.url)
+        return image_list
+
+    class Meta:
+        model = Room
+        exclude = ('brokerAgency',)
+         

--- a/tiptapProject/api/serializers.py
+++ b/tiptapProject/api/serializers.py
@@ -2,10 +2,25 @@ from rest_framework import serializers
 from app.models import BrokerAgency, CheckList, Image, Room, RoomInfo, Tag
 
 # RoomInfoSerializer: Created by @ssanghy on checklist
-class RoomInfoSerializer(serializers.ModelSerializer):
+class RoomInfoForRoomSerializer(serializers.ModelSerializer):
     class Meta:
         model = RoomInfo
-        exclude = ('roominfo_id', )
+        exclude = (
+            'roominfo_id',
+            'detailInfo_is_moldy',
+            'detailInfo_is_leak',
+            'detailInfo_is_bug',
+            'detailInfo_is_crack',
+            'detailInfo_soundproof',
+            'detailInfo_window_size',
+            'detailInfo_main_direction',
+            'detailInfo_ventilator',
+            'detailInfo_ventilation',
+            'detailInfo_external_noise',
+            'detailInfo_water_pressure',
+            'detailInfo_drainage',
+            'detailInfo_hot_water',
+        )
 
 
 class TagSerializer(serializers.ModelSerializer):
@@ -21,7 +36,7 @@ class BrokerAgencySerializer(serializers.ModelSerializer):
 
 
 class RoomSerializer(serializers.ModelSerializer):
-    roomInfo = RoomInfoSerializer()
+    roomInfo = RoomInfoForRoomSerializer()
     tag = TagSerializer(many=True, read_only=True)
     thumbnail = serializers.SerializerMethodField()
     images = serializers.SerializerMethodField()

--- a/tiptapProject/api/urls.py
+++ b/tiptapProject/api/urls.py
@@ -2,6 +2,5 @@ from django.urls import path
 from api import views
 
 urlpatterns = [
-    path("checklist/", views.ChecklistAPIView.as_view(actions={"get": "list", "post": "create"})),
-    path("checklist/<int:pk>/", views.ChecklistAPIView.as_view(actions={"get": "retrieve"})),
+    path('rooms/', views.RoomAPIView.as_view(actions={"get": "list"})),
 ]

--- a/tiptapProject/api/urls.py
+++ b/tiptapProject/api/urls.py
@@ -2,5 +2,5 @@ from django.urls import path
 from api import views
 
 urlpatterns = [
-    path('rooms/', views.RoomAPIView.as_view(actions={"get": "list"})),
+    path('rooms/', views.RoomAPIView.as_view(actions={"get": "retrieve"})),
 ]

--- a/tiptapProject/api/views.py
+++ b/tiptapProject/api/views.py
@@ -1,6 +1,32 @@
 from rest_framework import status
 from rest_framework.response import Response
-from rest_framework.viewsets import ModelViewSet
+from rest_framework.viewsets import ModelViewSet, ReadOnlyModelViewSet
 
-class ChecklistAPIView(ModelViewSet):
-    pass
+from api.serializers import RoomSerializer
+from app.models import Room
+
+class RoomAPIView(ReadOnlyModelViewSet):
+    """RoomAPIView
+    
+    RoomAPIView는 GET 요청이 발생할 경우 해당하는 매물의 정보를 응답하기 위해 사용됩니다.
+    RoomAPIView는 읽기 요청(GET)에만 정상적으로 응답합니다.
+    RoomAPIView를 통해 새로운 매물을 등록할 수 없습니다.
+
+    On progress:
+        지도 뷰에 따른 필터링을 개발 중입니다.
+    """
+    queryset = Room.objects.all().select_related('roomInfo')
+    serializer_class = RoomSerializer
+
+    def list(self, request, *args, **kwargs):
+        queryset = self.filter_queryset(self.get_queryset())
+        
+        page = self.paginate_queryset(queryset)
+        if page:
+            serializer = self.get_serializer(queryset, many=True)
+            return self.get_paginated_response(serializer.data)
+        
+        serializer = self.get_serializer(queryset, many=True)
+        
+        response_data = {"total": len(serializer.data), "rooms": serializer.data}
+        return Response(response_data)

--- a/tiptapProject/api/views.py
+++ b/tiptapProject/api/views.py
@@ -5,6 +5,8 @@ from rest_framework.viewsets import ModelViewSet, ReadOnlyModelViewSet
 from api.serializers import RoomSerializer
 from app.models import Room
 
+from app.utils import string_to_list
+
 class RoomAPIView(ReadOnlyModelViewSet):
     """RoomAPIView
     
@@ -18,8 +20,19 @@ class RoomAPIView(ReadOnlyModelViewSet):
     queryset = Room.objects.all().select_related('roomInfo')
     serializer_class = RoomSerializer
 
-    def list(self, request, *args, **kwargs):
-        queryset = self.filter_queryset(self.get_queryset())
+    """def filter_queryset(self, queryset):
+        queryset = super().filter_queryset(queryset)
+        start, center, end = string_to_list(self.request.query_params.get('location'))
+        queryset = queryset.filter(
+            roomInfo__basicInfo_location_x__gte=start[0],
+            roomInfo__basicInfo_location_x__lte=end[0],
+            roomInfo__basicInfo_location_y__gte=start[1],
+            roomInfo__basicInfo_location_y__lte=end[1]
+        )
+        return queryset"""
+
+    """def list(self, request, *args, **kwargs):
+        queryset = self.get_queryset()
         
         page = self.paginate_queryset(queryset)
         if page:
@@ -28,5 +41,29 @@ class RoomAPIView(ReadOnlyModelViewSet):
         
         serializer = self.get_serializer(queryset, many=True)
         
+        response_data = {"total": len(serializer.data), "rooms": serializer.data}
+        return Response(response_data)"""
+    
+    def retrieve(self, request, *args, **kwargs):
+        """
+        queryset = self.filter_queryset(self.get_queryset())
+        serializer = self.get_serializer(queryset, many=True)
+        """
+        left_bottom, middle, right_top = string_to_list(request.GET.get("location","[[-100,-100],[0,0],[200,200]]")) #location없으면 기본 값 가져옴
+        check = self.filter_queryset(self.get_queryset()).extra(
+            select={'manhattan_distance': f'ABS(basicInfo_location_x - {middle[0]}) + ABS(basicInfo_location_y - {middle[1]})'},
+            where={f'''basicInfo_location_x > {left_bottom[0]} and basicInfo_location_y > {left_bottom[1]}
+                   and basicInfo_location_x < {right_top[0]} and basicInfo_location_y <{right_top[1]}'''}
+        ).order_by('manhattan_distance')
+
+        queryset = self.filter_queryset(check)
+
+        page = self.paginate_queryset(queryset)
+        if page is not None:
+            serializer = self.get_serializer(page, many=True)
+            return self.get_paginated_response(serializer.data)
+
+        serializer = self.get_serializer(queryset, many=True)
+
         response_data = {"total": len(serializer.data), "rooms": serializer.data}
         return Response(response_data)

--- a/tiptapProject/app/models.py
+++ b/tiptapProject/app/models.py
@@ -210,7 +210,10 @@ class Interest(models.Model):
     user = models.ForeignKey(
         settings.AUTH_USER_MODEL, default=1, on_delete=models.CASCADE
     )
-    room = models.ForeignKey(Room, on_delete=models.CASCADE)
+    room = models.ForeignKey(Room, related_name='interest', on_delete=models.CASCADE)
+
+    def __unicode__(self):
+        return self.interest_id
 
 
 ### 확정 매물 ###

--- a/tiptapProject/app/models.py
+++ b/tiptapProject/app/models.py
@@ -190,11 +190,8 @@ class Tag(models.Model):
 class Room(models.Model):
     room_id = models.AutoField(primary_key=True)
     roomInfo = models.OneToOneField(RoomInfo, on_delete=models.CASCADE)
-    brokerAgency = models.ForeignKey(BrokerAgency, on_delete=models.CASCADE, blank=True, null=True)
-    # tag = models.ManyToManyField(Tag, blank=True, null=True)
-    tag = models.ManyToManyField(Tag)
-
-    # TODO: tag 추가하기
+    brokerAgency = models.ForeignKey(BrokerAgency, on_delete=models.CASCADE)
+    tag = models.ManyToManyField(Tag, blank=True, null=True)
 
 
 ### 체크리스트 ###

--- a/tiptapProject/app/models.py
+++ b/tiptapProject/app/models.py
@@ -178,7 +178,7 @@ class RoomInfo(models.Model):
 
 
 class Image(models.Model):
-    basicInfo = models.ForeignKey(RoomInfo, on_delete=models.CASCADE)
+    roomInfo = models.ForeignKey(RoomInfo, on_delete=models.CASCADE)
     image = models.ImageField(upload_to=rename_imagefile_to_uuid)
 
 
@@ -190,14 +190,15 @@ class Tag(models.Model):
 class Room(models.Model):
     room_id = models.AutoField(primary_key=True)
     roomInfo = models.OneToOneField(RoomInfo, on_delete=models.CASCADE)
-    brokerAgency = models.ForeignKey(BrokerAgency, on_delete=models.CASCADE)
-    tag = models.ManyToManyField(Tag, blank=True, null=True)
+    brokerAgency = models.ForeignKey(BrokerAgency, on_delete=models.CASCADE, blank=True, null=True)
+    # tag = models.ManyToManyField(Tag, blank=True, null=True)
+    tag = models.ManyToManyField(Tag)
 
     # TODO: tag 추가하기
 
 
 ### 체크리스트 ###
-class Checklist(models.Model):
+class CheckList(models.Model):
     checklist_id = models.AutoField(primary_key=True)
     roomInfo = models.OneToOneField(RoomInfo, on_delete=models.CASCADE)
     room = models.ForeignKey(Room, blank=True, null=True, on_delete=models.SET_NULL)
@@ -222,4 +223,4 @@ class ConfirmedRoom(models.Model):
         settings.AUTH_USER_MODEL, default=1, on_delete=models.CASCADE
     )
     room = models.ForeignKey(Room, on_delete=models.DO_NOTHING)
-    checklist = models.ForeignKey(Checklist, on_delete=models.CASCADE)
+    checklist = models.ForeignKey(CheckList, on_delete=models.CASCADE)

--- a/tiptapProject/app/tests.sql
+++ b/tiptapProject/app/tests.sql
@@ -1,0 +1,49 @@
+-- SQLite
+
+-- Insert the tag example
+INSERT INTO app_tag (tag_id, tag_name)
+VALUES (1, "왕십리역 6번 출구");
+
+INSERT INTO app_tag (tag_id, tag_name)
+VALUES (2, "소음 없는 방");
+
+INSERT INTO app_tag (tag_id, tag_name)
+VALUES (3, "자취생 추천");
+
+-- Insert the broker example
+INSERT INTO app_brokeragency (brokerAgency_id, brokerAgency_name, brokerAgency_representative_name, brokerAgency_number1, brokerAgency_number2, brokerAgency_location, brokerAgency_company_registration_number, brokerAgency_registration_number, brokerAgency_created_at, brokerAgency_updated_at)
+VALUES (1, "뚜벅뚜벅 공인중개사", "김멋사", "010-0000-0000", "02-0000-0000", "서울시 성동구 왕십리로 222", 1, 1, 2022-08-08, 2022-08-08);
+
+INSERT INTO app_brokeragency (brokerAgency_id, brokerAgency_name, brokerAgency_representative_name, brokerAgency_number1, brokerAgency_number2, brokerAgency_location, brokerAgency_company_registration_number, brokerAgency_registration_number, brokerAgency_created_at, brokerAgency_updated_at)
+VALUES (2, "이집저집 공인중개사", "박멋사", "010-1111-1111", "02-1111-1111", "서울시 성동구 왕십리로 222", 2, 2, 2022-08-08, 2022-08-08);
+
+-- Insert the room info example
+INSERT INTO app_roominfo (roominfo_id, basicInfo_location_x, basicInfo_location_y, basicInfo_brokerAgency, basicInfo_move_in_date, basicInfo_brokerAgency_contact, basicInfo_room_type, basicInfo_deposit, basicInfo_monthly_rent, basicInfo_maintenance_fee, basicInfo_floor, basicInfo_area, basicInfo_number_of_rooms, basicInfo_interior_structure, option_gas_stove, option_induction, option_microwave, option_refrigerator, option_washing_machine, option_air_conditioner, option_internet, option_tv, option_wifi, option_closet, option_cabinet, option_shoe_rack, option_bed, option_desk, option_chair, option_drying_rack, detailInfo_is_moldy, detailInfo_is_leak, detailInfo_is_bug, detailInfo_is_crack, detailInfo_window_size, detailInfo_water_pressure, detailInfo_drainage, detailInfo_hot_water)
+VALUES (1, 36.0, 36.0, "뚜벅뚜벅 공인중개사", "즉시 입주", "010-0000-0000", "M", 10000000, 500000, 70000, 1, 8.0, "1", "O", false, true, false, true, true, true, true, false, true, false, false, true, false, false, false, false, false, false, false, false, "L", "S", "S", "S");
+
+INSERT INTO app_roominfo (roominfo_id, basicInfo_location_x, basicInfo_location_y, basicInfo_brokerAgency, basicInfo_move_in_date, basicInfo_brokerAgency_contact, basicInfo_room_type, basicInfo_deposit, basicInfo_monthly_rent, basicInfo_maintenance_fee, basicInfo_floor, basicInfo_area, basicInfo_number_of_rooms, basicInfo_interior_structure, option_gas_stove, option_induction, option_microwave, option_refrigerator, option_washing_machine, option_air_conditioner, option_internet, option_tv, option_wifi, option_closet, option_cabinet, option_shoe_rack, option_bed, option_desk, option_chair, option_drying_rack, detailInfo_is_moldy, detailInfo_is_leak, detailInfo_is_bug, detailInfo_is_crack, detailInfo_window_size, detailInfo_water_pressure, detailInfo_drainage, detailInfo_hot_water)
+VALUES (2, 35.9, 35.9, "이집저집 공인중개사", "상의 후 결정", "010-1111-1111", "M", 20000000, 200000, 30000, 1, 7.0, "1", "O", true, false, false, true, true, true, true, false, true, false, false, true, false, false, false, false, false, false, false, false, "L", "S", "S", "S");
+
+-- Insert the room example
+INSERT INTO app_room (room_id, roomInfo_id, brokerAgency_id)
+VALUES (1, 1, 1);
+
+INSERT INTO app_room (room_id, roomInfo_id, brokerAgency_id)
+VALUES (2, 2, 2);
+
+-- Insert the room_tag example
+INSERT INTO app_room_tag (id, room_id, tag_id)
+VALUES (1, 1, 1);
+
+INSERT INTO app_room_tag (id, room_id, tag_id)
+VALUES (2, 1, 2);
+
+INSERT INTO app_room_tag (id, room_id, tag_id)
+VALUES (3, 2, 1);
+
+-- Insert the image example
+INSERT INTO app_image (id, image, roomInfo_id)
+VALUES (1, "media/image/3e4edf1d81104b01a3b9779858090bbf.jpg", 1);
+
+INSERT INTO app_image (id, image, roomInfo_id)
+VALUES (2, "media/image/3e4edf1d81104b01a3b9779858090bbf.jpg", 2);

--- a/tiptapProject/app/tests.sql
+++ b/tiptapProject/app/tests.sql
@@ -1,4 +1,7 @@
 -- SQLite
+-- Before you run this query, please create a superuser in your terminal using
+-- "python manage.py createsuperuser"
+-- to test properly.
 
 -- Insert the tag example
 INSERT INTO app_tag (tag_id, tag_name)
@@ -47,3 +50,7 @@ VALUES (1, "media/image/3e4edf1d81104b01a3b9779858090bbf.jpg", 1);
 
 INSERT INTO app_image (id, image, roomInfo_id)
 VALUES (2, "media/image/3e4edf1d81104b01a3b9779858090bbf.jpg", 2);
+
+-- Insert the interest example
+INSERT INTO app_interest (interest_id, room_id, user_id)
+VALUES (1, 1, 1);

--- a/tiptapProject/app/utils.py
+++ b/tiptapProject/app/utils.py
@@ -1,12 +1,19 @@
 import os
+from typing import Tuple, List
 from uuid import uuid4
 
 
 #이미지 필드 이름 변경 (원래 파일 이름 -> uuid)
 def rename_imagefile_to_uuid(instance, filename):
-    upload_to = f'image' # 업로드 위치
+    upload_to = f'image/{instance.roomInfo.roominfo_id}' # 업로드 위치
     ext = filename.split('.')[-1]
     uuid = uuid4().hex
     filename = '{}.{}'.format(uuid, ext)
 
     return os.path.join(upload_to, filename)
+
+
+#  "[[0, 0], [1, 1], [2, 2]]" -> (['0', '0'], ['1', '1'], ['2', '2'])
+def string_to_list(loc : str) -> tuple([list([str]), list([str]), list([str])]):
+    locs = loc.replace("[", "").replace("]","").replace(" ", "").split(",")
+    return [locs[0],locs[1]],[locs[2],locs[3]],[locs[4],locs[5]]


### PR DESCRIPTION
매물 조회 API 기능을 완성했습니다.

수정 사항은 아래와 같습니다:
- app/models.py의 Interest 모델의 room에 related_name 추가
- api/serializers.py에 RoomInfoForRoomSerializer, TagSerializer, BrokerAgencySerializer, InterestForRoomSerializer, RoomSerializer 추가
- api/views.py에 RoomAPIView 추가
- app에 tests.sql 추가

앞으로 개발에서 고려해야 할 사항은 아래와 같습니다:
- 기존 브랜치들과 현 브랜치의 app/models.py 완전히 일치시키기
- api/serializers.py의 중복 serializer 정리