### PR TITLE
#7 makemigrations 시 기존 레코드와 충돌하는 오류 수정

### DIFF
--- a/tiptapProject/app/models.py
+++ b/tiptapProject/app/models.py
@@ -2,7 +2,7 @@ from django.conf import settings
 from django.db import models
 from django.core.validators import RegexValidator
 
-from .utils import rename_imagefile_to_uuid
+from .utils import rename_imagefile_to_uuid, local_time
 
 
 
@@ -186,14 +186,14 @@ class Tag(models.Model):
     tag_id = models.AutoField(primary_key=True)
     tag_name = models.CharField(max_length=20)
 
+
 ### 매물 ###
 class Room(models.Model):
     room_id = models.AutoField(primary_key=True)
-    room_created_at = models.DateTimeField(auto_now_add=True)
+    room_created_at = models.DateTimeField(default=local_time, editable=False)
     roomInfo = models.OneToOneField(RoomInfo, on_delete=models.CASCADE)
     brokerAgency = models.ForeignKey(BrokerAgency, on_delete=models.CASCADE, blank=True, null=True)
     tag = models.ManyToManyField(Tag)
-    
 
 
 ### 체크리스트 ###

--- a/tiptapProject/app/utils.py
+++ b/tiptapProject/app/utils.py
@@ -1,6 +1,7 @@
 import os
 from typing import Tuple, List
 from uuid import uuid4
+from django.utils import timezone
 
 # 이미지 필드 이름 변경 (원래 파일 이름 -> uuid)
 import app
@@ -26,3 +27,6 @@ def remove_image(url):
 def string_to_list(loc: str) -> tuple([list([str]), list([str]), list([str])]):
     locs = loc.replace("[", "").replace("]", "").replace(" ", "").split(",")
     return [locs[0], locs[1]], [locs[2], locs[3]], [locs[4], locs[5]]
+
+def local_time():
+    return timezone.localtime(timezone.now())


### PR DESCRIPTION
```python manage.py makemigrations``` 시 기존의 ```room_created_at``` 필드가 없는 레코드에 자동으로 현재 시간을 추가하도록 변경했습니다.

수정 사항은 아래와 같습니다:
- Room의 ```room_created_at```을 ```models.DateTimeField(default=local_time, editable=False)```로 변경
- ```tiptapProject/app/utils.py```에 ```local_time``` 함수 추가